### PR TITLE
0.6.2-alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ fabric.properties
 
 *.env
 src/main/resources/settings.json
+/target/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ implementation 'dev.alphaserpentis:CoffeeCore:0.6.0-alpha'
 <dependency>
     <groupId>dev.alphaserpentis</groupId>
     <artifactId>CoffeeCore</artifactId>
-    <version>0.6.0-alpha-111023-SNAPSHOT</version>
+    <version>0.6.2-alpha-120423-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ functionality.
 <dependency>
     <groupId>dev.alphaserpentis</groupId>
     <artifactId>CoffeeCore</artifactId>
-    <version>0.6.0-alpha</version>
+    <version>0.6.2-alpha</version>
 </dependency>
 ```
 
 **Gradle**
 ```groovy
-implementation 'dev.alphaserpentis:CoffeeCore:0.6.0-alpha'
+implementation 'dev.alphaserpentis:CoffeeCore:0.6.2-alpha'
 ```
 
 #### Latest Snapshot:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.alphaserpentis</groupId>
     <artifactId>CoffeeCore</artifactId>
-    <version>0.6.2-alpha-SNAPSHOT</version>
+    <version>0.6.2-alpha-120423-SNAPSHOT</version>
     <name>Coffee Core</name>
     <description>Coffee Core is a JDA-based framework for Discord bots</description>
     <url>https://asrp.dev/#libraries</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.alphaserpentis</groupId>
     <artifactId>CoffeeCore</artifactId>
-    <version>0.6.2-alpha-120423-SNAPSHOT</version>
+    <version>0.6.2-alpha</version>
     <name>Coffee Core</name>
     <description>Coffee Core is a JDA-based framework for Discord bots</description>
     <url>https://asrp.dev/#libraries</url>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-beta.18</version>
+            <version>5.0.0-beta.19</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.alphaserpentis</groupId>
     <artifactId>CoffeeCore</artifactId>
-    <version>0.6.1-alpha</version>
+    <version>0.6.2-alpha-SNAPSHOT</version>
     <name>Coffee Core</name>
     <description>Coffee Core is a JDA-based framework for Discord bots</description>
     <url>https://asrp.dev/#libraries</url>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-beta.17</version>
+            <version>5.0.0-beta.18</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/dev/alphaserpentis/coffeecore/commands/BotCommand.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/commands/BotCommand.java
@@ -686,7 +686,7 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
         final InteractionHook interactHook = event.getHook();
         final boolean msgIsEphemeral = determineEphemeralStatus(event);
         final List<CommandHook> preExecHooks = commandHooks.stream()
-                .filter(hook -> hook.getTypeOfHook() == CommandHook.TypeOfHook.PRE_EXECUTION)
+                .filter(hook -> hook.getTypeOfHook() == CommandHook.Type.PRE_EXECUTION)
                 .toList();
 
         try {
@@ -698,19 +698,21 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
                     ArrayList<FileUpload> files = new ArrayList<>();
 
                     preExecHooks.forEach(
-                            hook -> hook.execute(this, event, null).ifPresent(rawResponse -> {
-                                    if(rawResponse instanceof CommandResponse<?> cmdResponse) {
-                                        embeds.addAll(
-                                                List.of((MessageEmbed[]) cmdResponse.messageResponse())
-                                        );
+                            hook -> hook
+                                    .execute(this, event, null)
+                                    .ifPresent(rawResponse -> {
+                                        if(rawResponse instanceof CommandResponse<?> cmdResponse) {
+                                            embeds.addAll(
+                                                    List.of((MessageEmbed[]) cmdResponse.messageResponse())
+                                            );
 
-                                        try(var fileUpload = cmdResponse.fileUpload()) {
-                                            if(fileUpload != null) files.add(fileUpload);
-                                        } catch (IOException e) {
-                                            throw new RuntimeException(e);
+                                            try(var fileUpload = cmdResponse.fileUpload()) {
+                                                if(fileUpload != null) files.add(fileUpload);
+                                            } catch (IOException e) {
+                                                throw new RuntimeException(e);
+                                            }
                                         }
-                                    }
-                            })
+                                    })
                     );
 
                     if(!embeds.isEmpty()) {
@@ -742,20 +744,22 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
                     final String[] lastResponse = new String[1];
 
                     preExecHooks.forEach(
-                            hook -> hook.execute(this, event, null).ifPresent(rawResponse -> {
-                                if(rawResponse instanceof CommandResponse<?> cmdResponse) {
-                                    if(cmdResponse.messageResponse() instanceof MessageEmbed[])
-                                        embeds.addAll(List.of((MessageEmbed[]) cmdResponse.messageResponse()));
-                                    else
-                                        lastResponse[0] = (String) cmdResponse.messageResponse()[0];
+                            hook -> hook
+                                    .execute(this, event, null)
+                                    .ifPresent(rawResponse -> {
+                                        if(rawResponse instanceof CommandResponse<?> cmdResponse) {
+                                            if(cmdResponse.messageResponse() instanceof MessageEmbed[] msgResponse)
+                                                embeds.addAll(List.of(msgResponse));
+                                            else
+                                                lastResponse[0] = (String) cmdResponse.messageResponse()[0];
 
-                                    try(var fileUpload = cmdResponse.fileUpload()) {
-                                        if(fileUpload != null) files.add(fileUpload);
-                                    } catch (IOException e) {
-                                        throw new RuntimeException(e);
-                                    }
-                                }
-                            })
+                                            try(var fileUpload = cmdResponse.fileUpload()) {
+                                                if(fileUpload != null) files.add(fileUpload);
+                                            } catch (IOException e) {
+                                                throw new RuntimeException(e);
+                                            }
+                                        }
+                                    })
                     );
 
                     if(!files.isEmpty()) {

--- a/src/main/java/dev/alphaserpentis/coffeecore/commands/ButtonCommand.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/commands/ButtonCommand.java
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Optional;
 
 /**
  * A command that can utilize buttons
@@ -39,8 +40,9 @@ public abstract class ButtonCommand<T, E extends GenericCommandInteractionEvent>
     /**
      * This method is called when a button is pressed.
      * @param event The event that triggered the button press.
+     * @return An optional object after button execution. This may be empty.
      */
-    public abstract void runButtonInteraction(@NonNull final ButtonInteractionEvent event);
+    public abstract Optional<?> runButtonInteraction(@NonNull final ButtonInteractionEvent event);
 
     /**
      * This method is called when the command is executed which may add buttons to a message.

--- a/src/main/java/dev/alphaserpentis/coffeecore/commands/ModalCommand.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/commands/ModalCommand.java
@@ -3,10 +3,14 @@ package dev.alphaserpentis.coffeecore.commands;
 import io.reactivex.rxjava3.annotations.NonNull;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 
+import java.util.Optional;
+
 public interface ModalCommand {
     /**
      * This method is called when a modal is pressed.
      * @param event The event that triggered the modal press.
+     * @return An optional object after modal execution. This may be empty.
      */
-    void runModalInteraction(@NonNull final ModalInteractionEvent event);
+    @NonNull
+    Optional<?> runModalInteraction(@NonNull final ModalInteractionEvent event);
 }

--- a/src/main/java/dev/alphaserpentis/coffeecore/data/bot/CommandResponse.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/data/bot/CommandResponse.java
@@ -2,20 +2,28 @@ package dev.alphaserpentis.coffeecore.data.bot;
 
 import io.reactivex.rxjava3.annotations.Nullable;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.utils.FileUpload;
 
 /**
  * A record that holds the response to a command. If both {@link #messageResponse} and {@link #messageIsEphemeral}
  * are null, an {@link IllegalArgumentException} will be thrown.
  * @param messageResponse The response to the command which is var args of several {@link MessageEmbed} or a <b>SINGLE</b> {@link String}
  * @param forgiveRatelimit Whether the bot should forgive the ratelimit or not.
+ * @param fileUpload The file to upload with the response. Only works if {@link T} is a {@link MessageEmbed}.
  * @param messageIsEphemeral Whether the response should be ephemeral or not.
  * @param <T> The type of the response which must be either a {@link MessageEmbed} or a {@link String}.
  */
-public record CommandResponse<T>(Boolean messageIsEphemeral, Boolean forgiveRatelimit, T... messageResponse) {
+public record CommandResponse<T>(
+        Boolean messageIsEphemeral,
+        Boolean forgiveRatelimit,
+        FileUpload fileUpload,
+        T... messageResponse
+) {
     @SafeVarargs
     public CommandResponse(
             @Nullable Boolean messageIsEphemeral,
             @Nullable Boolean forgiveRatelimit,
+            @Nullable FileUpload fileUpload,
             @Nullable T... messageResponse
     ) {
         if (messageResponse != null) {
@@ -34,7 +42,17 @@ public record CommandResponse<T>(Boolean messageIsEphemeral, Boolean forgiveRate
 
         this.messageResponse = messageResponse;
         this.forgiveRatelimit = forgiveRatelimit;
+        this.fileUpload = fileUpload;
         this.messageIsEphemeral = messageIsEphemeral;
+    }
+
+    @SuppressWarnings("unchecked")
+    public CommandResponse(
+            @Nullable Boolean messageIsEphemeral,
+            @Nullable Boolean forgiveRatelimit,
+            @Nullable MessageEmbed messageResponse
+    ) {
+        this(messageIsEphemeral, forgiveRatelimit, null, (T[]) new MessageEmbed[]{messageResponse});
     }
 
     @SuppressWarnings("unchecked")
@@ -42,7 +60,16 @@ public record CommandResponse<T>(Boolean messageIsEphemeral, Boolean forgiveRate
             @Nullable Boolean messageIsEphemeral,
             @Nullable MessageEmbed messageResponse
     ) {
-        this(messageIsEphemeral, false, (T[]) new MessageEmbed[]{messageResponse});
+        this(messageIsEphemeral, false, null, (T[]) new MessageEmbed[]{messageResponse});
+    }
+
+    @SuppressWarnings("unchecked")
+    public CommandResponse(
+            @Nullable Boolean messageIsEphemeral,
+            @Nullable FileUpload fileUpload,
+            @Nullable MessageEmbed messageResponse
+    ) {
+        this(messageIsEphemeral, false, fileUpload, (T[]) new MessageEmbed[]{messageResponse});
     }
 
     @SuppressWarnings("unchecked")
@@ -50,7 +77,7 @@ public record CommandResponse<T>(Boolean messageIsEphemeral, Boolean forgiveRate
             @Nullable Boolean messageIsEphemeral,
             @Nullable MessageEmbed... messageResponse
     ) {
-        this(messageIsEphemeral, false, (T[]) messageResponse);
+        this(messageIsEphemeral, false, null, (T[]) messageResponse);
     }
 
     @SuppressWarnings("unchecked")
@@ -58,6 +85,6 @@ public record CommandResponse<T>(Boolean messageIsEphemeral, Boolean forgiveRate
             @Nullable Boolean messageIsEphemeral,
             @Nullable String messageResponse
     ) {
-        this(messageIsEphemeral, false, (T[]) new String[]{messageResponse});
+        this(messageIsEphemeral, false, null, (T[]) new String[]{messageResponse});
     }
 }

--- a/src/main/java/dev/alphaserpentis/coffeecore/handler/api/discord/commands/CommandsHandler.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/handler/api/discord/commands/CommandsHandler.java
@@ -411,7 +411,7 @@ public class CommandsHandler extends ListenerAdapter {
     ) {
         var hooks = cmd.getCommandHooks()
                 .stream()
-                .filter(hook -> hook.getTypeOfHook() == CommandHook.TypeOfHook.POST_EXECUTION)
+                .filter(hook -> hook.getTypeOfHook() == CommandHook.Type.POST_EXECUTION)
                 .toList();
 
         hooks.forEach(hook -> hook.execute(cmd, event, msg));
@@ -424,7 +424,7 @@ public class CommandsHandler extends ListenerAdapter {
     ) {
         var hooks = cmd.getCommandHooks()
                 .stream()
-                .filter(hook -> hook.getTypeOfHook() == CommandHook.TypeOfHook.POST_EXECUTION)
+                .filter(hook -> hook.getTypeOfHook() == CommandHook.Type.POST_EXECUTION)
                 .toList();
 
         hooks.forEach(hook -> hook.execute(cmd, event, data));

--- a/src/main/java/dev/alphaserpentis/coffeecore/handler/api/discord/commands/CommandsHandler.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/handler/api/discord/commands/CommandsHandler.java
@@ -4,12 +4,15 @@ import dev.alphaserpentis.coffeecore.commands.BotCommand;
 import dev.alphaserpentis.coffeecore.commands.ButtonCommand;
 import dev.alphaserpentis.coffeecore.commands.ModalCommand;
 import dev.alphaserpentis.coffeecore.core.CoffeeCore;
+import dev.alphaserpentis.coffeecore.hook.CommandHook;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.annotations.Nullable;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent;
@@ -168,7 +171,7 @@ public class CommandsHandler extends ListenerAdapter {
                 );
                 Message msg = cmd.handleReply(event, cmd);
 
-                BotCommand.letMessageExpire(cmd, msg);
+                executePostExecutionHook(cmd, event, msg);
             } catch(Exception e) {
                 handleInteractionError(e);
             }
@@ -185,7 +188,7 @@ public class CommandsHandler extends ListenerAdapter {
                 );
                 Message msg = cmd.handleReply(event, cmd);
 
-                BotCommand.letMessageExpire(cmd, msg);
+                executePostExecutionHook(cmd, event, msg);
             } catch(Exception e) {
                 handleInteractionError(e);
             }
@@ -202,7 +205,7 @@ public class CommandsHandler extends ListenerAdapter {
                 );
                 Message msg = cmd.handleReply(event, cmd);
 
-                BotCommand.letMessageExpire(cmd, msg);
+                executePostExecutionHook(cmd, event, msg);
             } catch(Exception e) {
                 handleInteractionError(e);
             }
@@ -217,8 +220,9 @@ public class CommandsHandler extends ListenerAdapter {
                 var cmd = Objects.requireNonNull(
                         (ButtonCommand<?, ?>) getCommand(buttonId.substring(0, buttonId.indexOf("_")))
                 );
+                var optional = cmd.runButtonInteraction(event).orElse(null);
 
-                cmd.runButtonInteraction(event);
+                executePostExecutionHook(cmd, event, optional);
             } catch(Exception e) {
                 handleInteractionError(e);
             }
@@ -231,10 +235,11 @@ public class CommandsHandler extends ListenerAdapter {
             try {
                 String modalId = Objects.requireNonNull(event.getModalId());
                 var cmd = Objects.requireNonNull(
-                        (ModalCommand) getCommand(modalId.substring(0, modalId.indexOf("_")))
+                        (BotCommand<?, ?>) getCommand(modalId.substring(0, modalId.indexOf("_")))
                 );
+                var optional = ((ModalCommand) cmd).runModalInteraction(event);
 
-                cmd.runModalInteraction(event);
+                executePostExecutionHook(cmd, event, optional);
             } catch(Exception e) {
                 handleInteractionError(e);
             }
@@ -397,6 +402,32 @@ public class CommandsHandler extends ListenerAdapter {
 
         listOfActiveGuildCommands.clear();
         detectedGuildCommandNames.clear();
+    }
+
+    protected void executePostExecutionHook(
+            @NonNull BotCommand<?, ?> cmd,
+            @NonNull GenericCommandInteractionEvent event,
+            @NonNull Message msg
+    ) {
+        var hooks = cmd.getCommandHooks()
+                .stream()
+                .filter(hook -> hook.getTypeOfHook() == CommandHook.TypeOfHook.POST_EXECUTION)
+                .toList();
+
+        hooks.forEach(hook -> hook.execute(cmd, event, msg));
+    }
+
+    protected void executePostExecutionHook(
+            @NonNull BotCommand<?, ?> cmd,
+            @NonNull GenericInteractionCreateEvent event,
+            @Nullable Object data
+    ) {
+        var hooks = cmd.getCommandHooks()
+                .stream()
+                .filter(hook -> hook.getTypeOfHook() == CommandHook.TypeOfHook.POST_EXECUTION)
+                .toList();
+
+        hooks.forEach(hook -> hook.execute(cmd, event, data));
     }
 
     /**

--- a/src/main/java/dev/alphaserpentis/coffeecore/hook/CommandHook.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/hook/CommandHook.java
@@ -15,15 +15,15 @@ import java.util.Optional;
  */
 @Experimental
 public abstract class CommandHook {
-    private final TypeOfHook typeOfHook;
+    private final Type type;
 
-    public enum TypeOfHook {
+    public enum Type {
         PRE_EXECUTION,
         POST_EXECUTION
     }
 
-    public CommandHook(@NonNull TypeOfHook typeOfHook) {
-        this.typeOfHook = typeOfHook;
+    public CommandHook(@NonNull Type type) {
+        this.type = type;
     }
 
     /**
@@ -50,7 +50,7 @@ public abstract class CommandHook {
      * @return Optional of CommandResponse to override the command response AND skip command execution
      */
     @NonNull
-    @SuppressWarnings({"UnusedReturnValue"})
+    @SuppressWarnings({"UnusedReturnValue", "UnusedParamValue"})
     public Optional<?> execute(
             @NonNull BotCommand<?, ?> cmd,
             @NonNull GenericInteractionCreateEvent event,
@@ -60,7 +60,7 @@ public abstract class CommandHook {
     }
 
     @NonNull
-    public TypeOfHook getTypeOfHook() {
-        return typeOfHook;
+    public Type getTypeOfHook() {
+        return type;
     }
 }

--- a/src/main/java/dev/alphaserpentis/coffeecore/hook/CommandHook.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/hook/CommandHook.java
@@ -1,0 +1,67 @@
+package dev.alphaserpentis.coffeecore.hook;
+
+import dev.alphaserpentis.coffeecore.commands.BotCommand;
+import dev.alphaserpentis.coffeecore.data.bot.CommandResponse;
+import io.reactivex.rxjava3.annotations.Experimental;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.annotations.Nullable;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
+
+import java.util.Optional;
+
+/**
+ * A hook that can be run before or after a <b>DEFERRED</b> command is executed.
+ */
+@Experimental
+public abstract class CommandHook {
+    private final TypeOfHook typeOfHook;
+
+    public enum TypeOfHook {
+        PRE_EXECUTION,
+        POST_EXECUTION
+    }
+
+    public CommandHook(@NonNull TypeOfHook typeOfHook) {
+        this.typeOfHook = typeOfHook;
+    }
+
+    /**
+     * Executes the hook and optionally returns a command response
+     * @param cmd The command that was triggered
+     * @param event The event that triggered the command
+     * @param msg The message that was sent
+     * @return Optional of CommandResponse to override the command response AND skip command execution
+     */
+    @NonNull
+    public Optional<?> execute(
+            @NonNull BotCommand<?, ?> cmd,
+            @NonNull GenericCommandInteractionEvent event,
+            @Nullable Message msg
+    ) {
+        return Optional.empty();
+    }
+
+    /**
+     * Executes the hook and optionally returns a command response
+     * @param cmd The command that was triggered
+     * @param event The (button/modal) event that triggered the command
+     * @param data The optional data that was returned from the command
+     * @return Optional of CommandResponse to override the command response AND skip command execution
+     */
+    @NonNull
+    @SuppressWarnings({"UnusedReturnValue"})
+    public Optional<?> execute(
+            @NonNull BotCommand<?, ?> cmd,
+            @NonNull GenericInteractionCreateEvent event,
+            @Nullable Object data
+    ) {
+        return Optional.empty();
+    }
+
+    @NonNull
+    public TypeOfHook getTypeOfHook() {
+        return typeOfHook;
+    }
+}

--- a/src/main/java/dev/alphaserpentis/coffeecore/hook/CommandHook.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/hook/CommandHook.java
@@ -1,7 +1,6 @@
 package dev.alphaserpentis.coffeecore.hook;
 
 import dev.alphaserpentis.coffeecore.commands.BotCommand;
-import dev.alphaserpentis.coffeecore.data.bot.CommandResponse;
 import io.reactivex.rxjava3.annotations.Experimental;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.annotations.Nullable;

--- a/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/MessageExpireHook.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/MessageExpireHook.java
@@ -1,0 +1,27 @@
+package dev.alphaserpentis.coffeecore.hook.defaults;
+
+import dev.alphaserpentis.coffeecore.commands.BotCommand;
+import dev.alphaserpentis.coffeecore.data.bot.CommandResponse;
+import dev.alphaserpentis.coffeecore.hook.CommandHook;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.annotations.Nullable;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
+
+import java.util.Optional;
+
+public class MessageExpireHook extends CommandHook {
+    public MessageExpireHook() {
+        super(TypeOfHook.POST_EXECUTION);
+    }
+
+    @Override
+    @NonNull
+    public Optional<CommandResponse<?>> execute(
+            @NonNull BotCommand<?, ?> cmd,
+            @NonNull GenericCommandInteractionEvent event,
+            @Nullable Message msg
+            ) {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/MessageExpireHook.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/MessageExpireHook.java
@@ -1,7 +1,6 @@
 package dev.alphaserpentis.coffeecore.hook.defaults;
 
 import dev.alphaserpentis.coffeecore.commands.BotCommand;
-import dev.alphaserpentis.coffeecore.data.bot.CommandResponse;
 import dev.alphaserpentis.coffeecore.hook.CommandHook;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.annotations.Nullable;
@@ -9,19 +8,32 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+/**
+ * Default implementation to make messages expire. Does not delete messages triggered by UI elements like buttons.
+ */
 public class MessageExpireHook extends CommandHook {
     public MessageExpireHook() {
-        super(TypeOfHook.POST_EXECUTION);
+        super(Type.POST_EXECUTION);
     }
 
     @Override
     @NonNull
-    public Optional<CommandResponse<?>> execute(
+    public Optional<Void> execute(
             @NonNull BotCommand<?, ?> cmd,
             @NonNull GenericCommandInteractionEvent event,
             @Nullable Message msg
-            ) {
+    ) {
+        if(msg != null) deleteMessage(cmd.getMessageExpirationLength(), msg);
+
         return Optional.empty();
+    }
+
+    private void deleteMessage(long timeToExpire, @NonNull Message msg) {
+        msg
+                .delete()
+                .delay(timeToExpire, TimeUnit.SECONDS)
+                .complete();
     }
 }

--- a/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/RatelimitHook.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/RatelimitHook.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  */
 public class RatelimitHook extends CommandHook {
     public RatelimitHook() {
-        super(TypeOfHook.PRE_EXECUTION);
+        super(Type.PRE_EXECUTION);
     }
 
     @Override

--- a/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/RatelimitHook.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/RatelimitHook.java
@@ -1,0 +1,47 @@
+package dev.alphaserpentis.coffeecore.hook.defaults;
+
+import dev.alphaserpentis.coffeecore.commands.BotCommand;
+import dev.alphaserpentis.coffeecore.data.bot.CommandResponse;
+import dev.alphaserpentis.coffeecore.hook.CommandHook;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.annotations.Nullable;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Default implementation to handle ratelimits automatically
+ */
+public class RatelimitHook extends CommandHook {
+    public RatelimitHook() {
+        super(TypeOfHook.PRE_EXECUTION);
+    }
+
+    @Override
+    @NonNull
+    public Optional<CommandResponse<?>> execute(
+            @NonNull BotCommand<?, ?> cmd,
+            @NonNull GenericCommandInteractionEvent event,
+            @Nullable Message ignored
+    ) {
+        long userId = event.getUser().getIdLong();
+        long ratelimitTime = cmd.getRatelimitMap().getOrDefault(userId, 0L);
+
+        if(ratelimitTime > Instant.now().getEpochSecond()) {
+            return Optional.of(new CommandResponse<>(cmd.isOnlyEphemeral(), generateEmbed(ratelimitTime).build()));
+        }
+
+        return Optional.empty();
+    }
+
+    @NonNull
+    private EmbedBuilder generateEmbed(long ratelimitTime) {
+        return new EmbedBuilder()
+                .setTitle("Ratelimited")
+                .setDescription("Ratelimit expires <t:" + ratelimitTime + ":R>.")
+                .setColor(0xFF0000);
+    }
+}

--- a/src/test/dev/alphaserpentis/examples/coffeecore/java/hello/HelloCommandButton.java
+++ b/src/test/dev/alphaserpentis/examples/coffeecore/java/hello/HelloCommandButton.java
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 public class HelloCommandButton extends ButtonCommand<MessageEmbed, SlashCommandInteractionEvent> {
     public HelloCommandButton() {
@@ -41,7 +42,7 @@ public class HelloCommandButton extends ButtonCommand<MessageEmbed, SlashCommand
     }
 
     @Override
-    public void runButtonInteraction(@NonNull ButtonInteractionEvent event) {
+    public Optional<?> runButtonInteraction(@NonNull ButtonInteractionEvent event) {
         String key = convertComponentIdToKey(event.getComponentId());
 
         switch (key) {
@@ -50,6 +51,8 @@ public class HelloCommandButton extends ButtonCommand<MessageEmbed, SlashCommand
             case "mystery" -> event.reply("How did you click on this?").queue();
             default -> throw new IllegalStateException("Unexpected value: " + key);
         }
+
+        return Optional.empty();
     }
 
     @Override

--- a/src/test/dev/alphaserpentis/examples/coffeecore/kotlin/hello/HelloCommandButton.kt
+++ b/src/test/dev/alphaserpentis/examples/coffeecore/kotlin/hello/HelloCommandButton.kt
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.components.ItemComponent
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle
+import java.util.*
 
 class HelloCommandButton: ButtonCommand<MessageEmbed, SlashCommandInteractionEvent>(
     BotCommandOptions().apply {
@@ -30,13 +31,15 @@ class HelloCommandButton: ButtonCommand<MessageEmbed, SlashCommandInteractionEve
         return CommandResponse(isOnlyEphemeral, eb.build())
     }
 
-    override fun runButtonInteraction(event: ButtonInteractionEvent) {
+    override fun runButtonInteraction(event: ButtonInteractionEvent): Optional<Any> {
         when (val key = convertComponentIdToKey(event.componentId)) {
             "hello" -> event.reply("Hello, ${event.user.asMention}!").queue()
             "goodbye" -> event.reply("Goodbye, ${event.user.asMention}!").queue()
             "mystery" -> event.reply("How did you click on this?").queue()
             else -> throw IllegalStateException("Unexpected value: $key")
         }
+
+        return Optional.empty()
     }
 
     override fun addButtonsToMessage(event: SlashCommandInteractionEvent): Collection<ItemComponent> {

--- a/src/test/dev/alphaserpentis/examples/coffeecore/kotlin/hello/HelloCommandEmbed.kt
+++ b/src/test/dev/alphaserpentis/examples/coffeecore/kotlin/hello/HelloCommandEmbed.kt
@@ -1,4 +1,4 @@
-package hello
+package dev.alphaserpentis.examples.coffeecore.kotlin.hello
 
 import dev.alphaserpentis.coffeecore.commands.BotCommand
 import dev.alphaserpentis.coffeecore.data.bot.CommandResponse

--- a/src/test/dev/alphaserpentis/examples/coffeecore/kotlin/hello/HelloWorld.kt
+++ b/src/test/dev/alphaserpentis/examples/coffeecore/kotlin/hello/HelloWorld.kt
@@ -1,12 +1,12 @@
-package hello
+package dev.alphaserpentis.examples.coffeecore.kotlin.hello
 
 import dev.alphaserpentis.coffeecore.core.CoffeeCore
 import dev.alphaserpentis.coffeecore.core.CoffeeCoreBuilder
 import dev.alphaserpentis.coffeecore.data.bot.AboutInformation
 import dev.alphaserpentis.coffeecore.data.bot.BotSettings
+import hello.HelloCommandText
 import io.github.cdimascio.dotenv.Dotenv
 import net.dv8tion.jda.api.JDABuilder
-import dev.alphaserpentis.examples.coffeecore.kotlin.hello.HelloCommandButton
 
 fun main() {
     val dotenv: Dotenv = Dotenv.load()


### PR DESCRIPTION
# Major Changes
- Deprecated and marked for removal beforeRunCommand and TypeOfEphemeral
- beforeRunCommand/TypeOfEphemeral replaced in favor of the CommandHook, enabling pre execution and post execution hooks to run. Logic in BotCommand.processDeferredCommand has been replaced.
- Ratelimit handling replaced with a pre-execution hook, replacing and deprecating BotCommand.checkAndHandleRateLimitedUser
- Message expiration handling replaced with a post-execution hook, replacing and deprecating letMessageExpire
- Marked deprecated BotCommandOptions constructors for removal
- BotCommand.retrieveAndProcessResponse returns a SimpleEntry containing the messageResponse and potential file upload
- Added the ability to attach images to messages

# Other Changes
- Update JDA to 5.0.0-beta.19
- If a command is inactive, the ratelimit is ignored
- ButtonCommand.runButtonInteraction now returns Optional<?>
- ModalCommand.runModalInteraction now returns Optional<?>