### PR TITLE
Optimizations + Limit Stack Trace Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ implementation 'dev.alphaserpentis:CoffeeCore:0.6.2-alpha'
 <dependency>
     <groupId>dev.alphaserpentis</groupId>
     <artifactId>CoffeeCore</artifactId>
-    <version>0.6.2-alpha-120423-SNAPSHOT</version>
+    <version>0.7.0-alpha-011924-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.alphaserpentis</groupId>
     <artifactId>CoffeeCore</artifactId>
-    <version>0.6.2-alpha</version>
+    <version>0.7.0-alpha-011924-SNAPSHOT</version>
     <name>Coffee Core</name>
     <description>Coffee Core is a JDA-based framework for Discord bots</description>
     <url>https://asrp.dev/#libraries</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.alphaserpentis</groupId>
     <artifactId>CoffeeCore</artifactId>
-    <version>0.7.0-alpha-011924-SNAPSHOT</version>
+    <version>0.7.0-alpha-012424-SNAPSHOT</version>
     <name>Coffee Core</name>
     <description>Coffee Core is a JDA-based framework for Discord bots</description>
     <url>https://asrp.dev/#libraries</url>

--- a/src/main/java/dev/alphaserpentis/coffeecore/commands/BotCommand.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/commands/BotCommand.java
@@ -60,7 +60,6 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
     protected final boolean messagesExpire;
     protected final CommandVisibility commandVisibility;
     protected final Command.Type commandType;
-    protected final TypeOfEphemeral ephemeralType;
     protected long globalCommandId;
     protected CoffeeCore core;
 
@@ -75,21 +74,6 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
          * @see Guild#upsertCommand(String, String)
          */
         GUILD
-    }
-
-    /**
-     * Types of ephemeral available for commands.
-     */
-    @Deprecated(forRemoval = true)
-    public enum TypeOfEphemeral {
-        /**
-         * The default ephemeral type. This will be set to the server's default ephemeral type.
-         */
-        DEFAULT,
-        /**
-         * Ephemeral type that enables the usage of {@link #beforeRunCommand(long, GenericCommandInteractionEvent)}
-         */
-        DYNAMIC
     }
 
     /**
@@ -111,7 +95,6 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
         protected boolean useDefaultHooks = true;
         protected CommandVisibility commandVisibility = CommandVisibility.GLOBAL;
         protected Command.Type commandType = Command.Type.SLASH;
-        protected TypeOfEphemeral typeOfEphemeral = TypeOfEphemeral.DEFAULT;
         protected Collection<Long> guildsToRegisterIn = List.of();
         protected Collection<CommandHook> commandHooks = new ArrayList<>();
 
@@ -123,65 +106,6 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
         ) {
             this.name = name;
             this.description = description;
-        }
-
-        @Deprecated(forRemoval = true)
-        public BotCommandOptions(
-                @NonNull String name,
-                @NonNull String description,
-                boolean onlyEmbed,
-                boolean onlyEphemeral,
-                @NonNull TypeOfEphemeral typeOfEphemeral
-        ) {
-            this.name = name;
-            this.description = description;
-            this.onlyEmbed = onlyEmbed;
-            this.onlyEphemeral = onlyEphemeral;
-            this.typeOfEphemeral = typeOfEphemeral;
-        }
-
-        @Deprecated(forRemoval = true)
-        public BotCommandOptions(
-                @NonNull String name,
-                @NonNull String description,
-                boolean onlyEmbed,
-                boolean onlyEphemeral,
-                @NonNull TypeOfEphemeral typeOfEphemeral,
-                boolean deferReplies
-        ) {
-            this.name = name;
-            this.description = description;
-            this.onlyEmbed = onlyEmbed;
-            this.onlyEphemeral = onlyEphemeral;
-            this.typeOfEphemeral = typeOfEphemeral;
-            this.deferReplies = deferReplies;
-        }
-
-        @Deprecated(forRemoval = true)
-        public BotCommandOptions(
-                @NonNull String name,
-                @NonNull String description,
-                long ratelimitLength,
-                long messageExpirationLength,
-                boolean onlyEmbed,
-                boolean onlyEphemeral,
-                @NonNull TypeOfEphemeral typeOfEphemeral,
-                boolean isActive,
-                boolean deferReplies,
-                boolean useRatelimits,
-                boolean messagesExpire
-        ) {
-            this.name = name;
-            this.description = description;
-            this.ratelimitLength = ratelimitLength;
-            this.messageExpirationLength = messageExpirationLength;
-            this.onlyEmbed = onlyEmbed;
-            this.onlyEphemeral = onlyEphemeral;
-            this.typeOfEphemeral = typeOfEphemeral;
-            this.isActive = isActive;
-            this.deferReplies = deferReplies;
-            this.useRatelimits = useRatelimits;
-            this.messagesExpire = messagesExpire;
         }
 
         /**
@@ -350,18 +274,6 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
         }
 
         /**
-         * Sets the command's type of ephemeral
-         * @param typeOfEphemeral The command's type of ephemeral
-         * @return {@link BotCommandOptions}
-         */
-        @NonNull
-        @Deprecated(forRemoval = true)
-        public BotCommandOptions setTypeOfEphemeral(@NonNull TypeOfEphemeral typeOfEphemeral) {
-            this.typeOfEphemeral = typeOfEphemeral;
-            return this;
-        }
-
-        /**
          * Sets the command's guilds to register in
          * <p>
          * This is only used if the command's visibility is {@link CommandVisibility#GUILD}. To apply to all guilds, leave the array empty!
@@ -399,9 +311,9 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
             if(description == null && commandType == Command.Type.SLASH)
                 throw new IllegalArgumentException("Description cannot be null for slash commands!");
             if(useRatelimits && ratelimitLength <= 0)
-                throw new IllegalArgumentException("Ratelimit length must be greater than 0!");
+                throw new IllegalArgumentException("Ratelimit length must be greater than 0 if using ratelimits!");
             if(messagesExpire && messageExpirationLength <= 0)
-                throw new IllegalArgumentException("Message expiration length must be greater than 0!");
+                throw new IllegalArgumentException("Message expiration length must be greater than 0 if messages expire!");
         }
     }
 
@@ -426,7 +338,6 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
         messagesExpire = options.messagesExpire;
         commandVisibility = options.commandVisibility;
         commandType = options.commandType;
-        ephemeralType = options.typeOfEphemeral;
         guildsToRegisterIn = options.guildsToRegisterIn;
         commandHooks = options.commandHooks;
 
@@ -469,23 +380,6 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
         guild
                 .upsertCommand(getJDACommandData(getCommandType(), getName(), getDescription()))
                 .queue();
-    }
-
-    /**
-     * A method that <b>REQUIRES</b> to be overridden if to be used for any {@link BotCommand} with an ephemeralType of
-     * {@link TypeOfEphemeral#DYNAMIC}
-     * <p>
-     * This method is currently only called if the command is <b>DEFERRED</b>.
-     * <p>
-     * Operations inside must NOT exceed the time it requires to <b>ACKNOWLEDGE</b> the API!
-     * @param userId is a long ID provided by Discord for the user calling the command
-     * @param event is a {@link E} that contains the interaction
-     * @return a nonnull {@link CommandResponse} containing either a {@link MessageEmbed} or String
-     */
-    @NonNull
-    @Deprecated(forRemoval = true)
-    public CommandResponse<T> beforeRunCommand(long userId, @NonNull E event) {
-        throw new UnsupportedOperationException("beforeRunCommand needs to be overridden!");
     }
 
     /**
@@ -627,12 +521,6 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
 
     public boolean doMessagesExpire() {
         return messagesExpire;
-    }
-
-    @NonNull
-    @Deprecated(forRemoval = true)
-    public TypeOfEphemeral getEphemeralType() {
-        return ephemeralType;
     }
 
     @NonNull
@@ -898,7 +786,7 @@ public abstract class BotCommand<T, E extends GenericCommandInteractionEvent> {
      * @param command The command that is being executed
      * @param message The message to delete
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static void letMessageExpire(@NonNull BotCommand<?, ?> command, @NonNull Message message) {
         if(command.doMessagesExpire())
             message.delete().queueAfter(command.getMessageExpirationLength(), TimeUnit.SECONDS);

--- a/src/main/java/dev/alphaserpentis/coffeecore/data/entity/EntityData.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/data/entity/EntityData.java
@@ -1,3 +1,6 @@
 package dev.alphaserpentis.coffeecore.data.entity;
 
+/**
+ * Empty class to be used as a common superclass for all entity data classes.
+ */
 public abstract class EntityData { }

--- a/src/main/java/dev/alphaserpentis/coffeecore/data/entity/UserData.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/data/entity/UserData.java
@@ -1,3 +1,23 @@
 package dev.alphaserpentis.coffeecore.data.entity;
 
-public class UserData extends EntityData { }
+import com.google.gson.annotations.SerializedName;
+
+public class UserData extends EntityData {
+    @SerializedName("showFullStackTrace")
+    private boolean showFullStackTrace = false;
+
+    public void setShowFullStackTrace(boolean showFullStackTrace) {
+        this.showFullStackTrace = showFullStackTrace;
+    }
+
+    public boolean getShowFullStackTrace() {
+        return showFullStackTrace;
+    }
+
+    @Override
+    public String toString() {
+        return "UserData{" +
+                "showFullStackTrace=" + showFullStackTrace +
+                '}';
+    }
+}

--- a/src/main/java/dev/alphaserpentis/coffeecore/handler/api/discord/commands/CommandsHandler.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/handler/api/discord/commands/CommandsHandler.java
@@ -32,12 +32,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
 /**
- * The handler for all the commands to be registered with the bot. This handles registration and execution of the commands.
+ * The handler for all the commands to be registered with the bot. This handles registration and execution of the
+ * commands.
  */
 public class CommandsHandler extends ListenerAdapter {
     /**
-     * The mapping of {@link BotCommand} that have been registered to the bot. This is used to check for commands that are already
-     * registered and update them if necessary.
+     * The mapping of {@link BotCommand} that have been registered to the bot. This is used to check for commands that
+     * are already registered and update them if necessary.
      */
     protected final HashMap<String, BotCommand<?, ?>> mapOfCommands = new HashMap<>();
     /**
@@ -93,9 +94,9 @@ public class CommandsHandler extends ListenerAdapter {
     }
 
     /**
-     * Provided a mapping of {@link BotCommand}, this will check for any commands that are already registered and update them if
-     * necessary. If the command is not registered, it will register it. If the command is registered, but not in the
-     * mapping, it will remove it.
+     * Provided a mapping of {@link BotCommand}, this will check for any commands that are already registered and update
+     * them if necessary. If the command is not registered, it will register it. If the command is registered, but not
+     * in the mapping, it will remove it.
      * @param mapOfCommands The mapping of commands to check and register
      * @param updateCommands Whether to update the commands if they are already registered
      */

--- a/src/main/java/dev/alphaserpentis/coffeecore/handler/api/discord/entities/DataHandler.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/handler/api/discord/entities/DataHandler.java
@@ -60,6 +60,28 @@ public class DataHandler<T extends EntityData> extends AbstractDataHandler<T> {
     }
 
     /**
+     * Gets the specified entity data.
+     * <p>
+     * <b>Implementation Note:</b> This method will create a new instance of the specified {@link EntityData} type if
+     * the entity data does not exist.
+     * @param entityType The identifier to check which mapping to use.
+     * @param id The ID of the entity (server/user).
+     * @return The entity data.
+     */
+    @Override
+    @NonNull
+    public T getEntityData(@NonNull String entityType, long id) {
+        T data = entityDataHashMap.get(entityType).get(id);
+
+        if(data == null) {
+            data = createNewEntityData(entityType);
+            entityDataHashMap.get(entityType).put(id, data);
+        }
+
+        return data;
+    }
+
+    /**
      * Creates a new instance of the specified {@link EntityData} type.
      * <p>
      * <b>This method should be overridden if you're extending this class or have additional entity types!</b>
@@ -68,7 +90,7 @@ public class DataHandler<T extends EntityData> extends AbstractDataHandler<T> {
      */
     @Override
     @SuppressWarnings("unchecked")
-    protected T createNewEntityData(@NonNull String entityType) {
+    public T createNewEntityData(@NonNull String entityType) {
         String type = getEntityTypes()
                 .stream()
                 .filter(type1 -> type1.getId().equals(entityType))

--- a/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/RatelimitHook.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/hook/defaults/RatelimitHook.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 
 /**
  * Default implementation to handle ratelimits automatically
+ * <p>
+ * This hook does <b>NOT</b> set the ratelimit for the user. It only checks if the user is ratelimited.
  */
 public class RatelimitHook extends CommandHook {
     public RatelimitHook() {

--- a/src/main/java/dev/alphaserpentis/coffeecore/serialization/EntityDataDeserializer.java
+++ b/src/main/java/dev/alphaserpentis/coffeecore/serialization/EntityDataDeserializer.java
@@ -40,10 +40,12 @@ public class EntityDataDeserializer<T extends EntityData> implements JsonDeseria
 
         for(Map.Entry<String, JsonElement> entry: object.entrySet()) {
             // Determine the entity data class
-            EntityType entityType = dataHandler.getEntityTypes().stream()
-                            .filter(type1 -> type1.getId().equals(entry.getKey()))
-                            .findFirst()
-                            .orElseThrow(() -> new JsonParseException("Invalid entity type: " + entry.getKey()));
+            EntityType entityType = dataHandler
+                    .getEntityTypes()
+                    .stream()
+                    .filter(type1 -> type1.getId().equals(entry.getKey()))
+                    .findFirst()
+                    .orElseThrow(() -> new JsonParseException("Invalid entity type: " + entry.getKey()));
             Map<String, JsonElement> innerObject = entry.getValue().getAsJsonObject().asMap();
 
             // Initialize the entity data map

--- a/src/test/dev/alphaserpentis/examples/coffeecore/java/custom/handler/CustomDataHandler.java
+++ b/src/test/dev/alphaserpentis/examples/coffeecore/java/custom/handler/CustomDataHandler.java
@@ -1,6 +1,5 @@
 package dev.alphaserpentis.examples.coffeecore.java.custom.handler;
 
-import com.google.gson.JsonDeserializer;
 import com.google.gson.reflect.TypeToken;
 import dev.alphaserpentis.coffeecore.data.entity.ServerData;
 import dev.alphaserpentis.coffeecore.handler.api.discord.entities.DataHandler;
@@ -17,7 +16,7 @@ public class CustomDataHandler extends DataHandler<CustomServerData> {
      *
      * @param path             The path to the server data file.
      * @param typeToken        The {@link TypeToken} of the mapping of user IDs to {@link ServerData}.
-     * @param jsonDeserializer The {@link JsonDeserializer} to deserialize the server data.
+     * @param jsonDeserializer The {@link EntityDataDeserializer} to deserialize the server data.
      * @throws IOException If the bot fails to read the server data file.
      */
     public CustomDataHandler(
@@ -29,7 +28,7 @@ public class CustomDataHandler extends DataHandler<CustomServerData> {
     }
 
     @Override
-    protected CustomServerData createNewEntityData() {
+    protected CustomServerData createNewEntityData(@NonNull String entityId) {
         return new CustomServerData();
     }
 }

--- a/src/test/dev/alphaserpentis/examples/coffeecore/java/custom/handler/CustomDataHandler.java
+++ b/src/test/dev/alphaserpentis/examples/coffeecore/java/custom/handler/CustomDataHandler.java
@@ -28,7 +28,7 @@ public class CustomDataHandler extends DataHandler<CustomServerData> {
     }
 
     @Override
-    protected CustomServerData createNewEntityData(@NonNull String entityId) {
+    public CustomServerData createNewEntityData(@NonNull String entityId) {
         return new CustomServerData();
     }
 }

--- a/src/test/dev/alphaserpentis/examples/coffeecore/java/hello/HelloError.java
+++ b/src/test/dev/alphaserpentis/examples/coffeecore/java/hello/HelloError.java
@@ -1,0 +1,24 @@
+package dev.alphaserpentis.examples.coffeecore.java.hello;
+
+import dev.alphaserpentis.coffeecore.commands.BotCommand;
+import dev.alphaserpentis.coffeecore.data.bot.CommandResponse;
+import io.reactivex.rxjava3.annotations.NonNull;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+
+public class HelloError extends BotCommand<String, SlashCommandInteractionEvent> {
+    public HelloError() {
+        super(
+                new BotCommandOptions()
+                        .setName("helloerror")
+                        .setDescription("Says hello to you! (It doesn't)")
+                        .setOnlyEmbed(false)
+                        .setOnlyEphemeral(false)
+        );
+    }
+
+    @Override
+    @NonNull
+    public CommandResponse<String> runCommand(long userId, @NonNull SlashCommandInteractionEvent event) {
+        throw new IllegalStateException("Oops! All errors!");
+    }
+}

--- a/src/test/dev/alphaserpentis/examples/coffeecore/java/hello/HelloWorld.java
+++ b/src/test/dev/alphaserpentis/examples/coffeecore/java/hello/HelloWorld.java
@@ -27,9 +27,10 @@ public class HelloWorld {
         HelloCommandText helloCommandText = new HelloCommandText();
         HelloCommandEmbed helloCommandEmbed = new HelloCommandEmbed();
         HelloCommandButton helloCommandButton = new HelloCommandButton();
+        HelloError helloError = new HelloError();
         CoffeeCoreBuilder<?> builder = new CoffeeCoreBuilder<>().setSettings(botSettings);
         CoffeeCore core = builder.build(dotenv.get("DISCORD_BOT_TOKEN"));
 
-        core.registerCommands(helloCommandText, helloCommandEmbed, helloCommandButton);
+        core.registerCommands(helloCommandText, helloCommandEmbed, helloCommandButton, helloError);
     }
 }

--- a/src/test/dev/alphaserpentis/examples/coffeecore/kotlin/custom/handler/CustomDataHandler.kt
+++ b/src/test/dev/alphaserpentis/examples/coffeecore/kotlin/custom/handler/CustomDataHandler.kt
@@ -20,7 +20,7 @@ class CustomDataHandler
     typeToken: TypeToken<Map<String, Map<Long?, CustomServerData?>?>>,
     jsonDeserializer: CustomEntityDataDeserializer
 ) : DataHandler<CustomServerData?>(path, typeToken, jsonDeserializer) {
-    override fun createNewEntityData(): CustomServerData {
+    override fun createNewEntityData(ignored: String): CustomServerData {
         return CustomServerData()
     }
 }


### PR DESCRIPTION
Closes #14

**Detailed Changelog**:
-----
- Stopped creating a new Gson object every time the executor was scheduled to write data
- Added a string parameter in `AbstractDataHandler.createNewEntityData()` to get the type's name
- `DataHandler.createNewEntityData` properly creates the respective objects
- Defined `UserData` structure
- Removed previously flagged items marked for removal
- Marked `BotCommand.letMessageExpire` for removal
- Restructured the `Settings` default command to separate between user/server settings
- Allow to toggle stack traces to show in its entirety
- Add new override to `AbstractDataHandler.getEntityData` in `DataHandler`
- Added new parameter in `BotCommand.handleError` to pass a user ID
- `BotCommand.handleError` no longer made static
- Clarified validation check in `BotCommand`
- Formatting